### PR TITLE
Update doco link to new unified URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ A basic repository to track multiple UEFN related diffs.
 | :---: | :---: | :---: | :---: |
 | FortniteGame | [`/Verse`](https://github.com/vz-creates/uefn/blob/main/Modules/FortniteGame/Verse/) | [`/UnrealEngine`](https://github.com/vz-creates/uefn/blob/main/Modules/FortniteGame/UnrealEngine/) | [`/Fortnite`](https://github.com/vz-creates/uefn/blob/main/Modules/FortniteGame/Fortnite/) |
 
-- [Verse Language Quick Reference by Epic Games](https://dev.epicgames.com/documentation/en-us/uefn/verse-language-quick-reference)
+- [Verse Language Quick Reference by Epic Games](https://dev.epicgames.com/documentation/en-us/fortnite/verse-language-quick-reference)
+- [Verse Language Style Guide by Epic Games](https://dev.epicgames.com/documentation/en-us/fortnite/verse-code-style-guide-in-unreal-editor-for-fortnite)
 
 ***
 


### PR DESCRIPTION
https://dev.epicgames.com/documentation/en-us/uefn/36-00-fortnite-ecosystem-updates-and-release-notes#fortnitedocumentationisnowcombined!
> **Fortnite Documentation is Now Combined!**
As mentioned in the last release, if you head over to Documentation in the Epic Developer Community, you’ll see that the tabs are gone and the docs are all in one streamlined set!

Also adds official style guide url